### PR TITLE
chore: update larastan package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     ],
     "require": {
         "php": "^8.1",
-        "nunomaduro/larastan": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.16",
-        "symfony/filesystem": "^6.0"
+        "symfony/filesystem": "^6.0",
+        "larastan/larastan": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging

### Problem statement
The `larastan` package has been moved to its own GitHub and therefore `nunomaduro/larastan` has been marked as abandoned. 

### Solution
I've updated Larastan to use the new package.

### Dependencies
n/a

### Test procedures
n/a

### Links

n/a

## Deployment

### Migrations
No

### Environment variables
n/a

### Deployment notes
n/a
