### PR TITLE
feat: set php unit method casing to snake case

### DIFF
--- a/phpcsfixer/config.php
+++ b/phpcsfixer/config.php
@@ -164,6 +164,7 @@ $rules = [
     'phpdoc_trim' => true,
     'phpdoc_types' => true,
     'phpdoc_var_without_name' => true,
+    'php_unit_method_casing' => 'snake_case',
     'return_type_declaration' => ['space_before' => 'none'],
     'self_accessor' => false,
     'self_static_accessor' => true,


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging

### Problem statement
Following a discussion held internally, we will be using snake casing for PHP unit method names.

### Solution
This PR adds the rule to fix method names. The documentation for this rule can be found here: https://mlocati.github.io/php-cs-fixer-configurator/#version:3.13|fixer:php_unit_method_casing